### PR TITLE
Add requestId field to PscDiscrepancySurvey

### DIFF
--- a/src/main/java/handler/Handler.java
+++ b/src/main/java/handler/Handler.java
@@ -29,7 +29,8 @@ public class Handler implements RequestHandler<S3Event, String> {
 
     @Override
     public String handleRequest(S3Event s3event, Context context) {
-        LOG.info("handleRequest entry");
+        String requestId = context.getAwsRequestId();
+        LOG.info("handleRequest entry for awsRequestId: {}", requestId);
         for (S3EventNotificationRecord record : s3event.getRecords()) {
             String s3Key = amazonS3Service.getKey(record);
             String s3Bucket = amazonS3Service.getBucket(record);
@@ -47,7 +48,8 @@ public class Handler implements RequestHandler<S3Event, String> {
                     PscDiscrepancyFoundListenerImpl listener = new PscDiscrepancyFoundListenerImpl(
                                     httpClient,
                                     "http://chpdev-pl6.internal.ch:21011/chips-restService/rest/chipsgeneric/pscDiscrepancies",
-                                    new ObjectMapper());
+                                    new ObjectMapper(),
+                                    requestId);
                     PscDiscrepancySurveyCsvProcessor csvParser =
                                     new PscDiscrepancySurveyCsvProcessor(extractedCsv, listener);
                     LOG.error("About to parse CSV");

--- a/src/main/java/handler/PscDiscrepancyFoundListenerImpl.java
+++ b/src/main/java/handler/PscDiscrepancyFoundListenerImpl.java
@@ -19,17 +19,20 @@ public class PscDiscrepancyFoundListenerImpl implements PscDiscrepancyCreatedLis
     private final CloseableHttpClient client;
     private final String postUrl;
     private final ObjectMapper objectMapper;
+    private final String requestId;
 
     public PscDiscrepancyFoundListenerImpl(CloseableHttpClient client, String postUrl,
-                    ObjectMapper objectMapper) {
+                    ObjectMapper objectMapper, String requestId) {
         this.client = client;
         this.postUrl = postUrl;
         this.objectMapper = objectMapper;
+        this.requestId = requestId;
     }
 
     @Override
     public boolean created(PscDiscrepancySurvey discrepancy) {
         try {
+            discrepancy.setRequestId(requestId);
             String discrepancyJson = objectMapper.writeValueAsString(discrepancy);
             StringEntity entity = new StringEntity(discrepancyJson);
             LOG.info("Callback for discrepancy: {}", discrepancyJson);

--- a/src/main/java/model/PscDiscrepancySurvey.java
+++ b/src/main/java/model/PscDiscrepancySurvey.java
@@ -15,8 +15,17 @@ public class PscDiscrepancySurvey {
     private String companyName;
     private String companyNumber;
     private String discrepancyType;
+    private String requestId;
 
     private List<PscDiscrepancySurveyQandA> questionsAndAnswers;
+
+    public String getRequestId() {
+        return requestId;
+    }
+
+    public void setRequestId(String requestId) {
+        this.requestId = requestId;
+    }
 
     public PscDiscrepancySurveyObligedEntity getObligedEntity() {
         return obligedEntity;
@@ -68,7 +77,8 @@ public class PscDiscrepancySurvey {
 
     @Override
     public String toString() {
-        return "PscDiscrepancy [obligedEntity=" + obligedEntity
+        return "PscDiscrepancy [requestId=" + requestId
+                        + ", obligedEntity=" + obligedEntity
                         + ", discrepancyIdentifiedOn=" + discrepancyIdentifiedOn
                         + ", discrepancyType=" + discrepancyType
                         + ", companyName=" + companyName

--- a/src/test/java/handler/PscDiscrepancyFoundListenerImplTest.java
+++ b/src/test/java/handler/PscDiscrepancyFoundListenerImplTest.java
@@ -47,8 +47,8 @@ public class PscDiscrepancyFoundListenerImplTest {
     private CloseableHttpClient client;
     @Captor
     private ArgumentCaptor<HttpPost> argCaptor;
-
-    private String REST_API = "http://test.ch:00000/chips";
+    private static final String CORRELATION_ID = "1234";
+    private static final String REST_API = "http://test.ch:00000/chips";
     private PscDiscrepancySurvey discrepancy;
 
     private PscDiscrepancyCreatedListener pscDiscrepancyFoundListenerImpl;
@@ -56,7 +56,7 @@ public class PscDiscrepancyFoundListenerImplTest {
     @BeforeEach
     public void setUp() {
         pscDiscrepancyFoundListenerImpl =
-                        new PscDiscrepancyFoundListenerImpl(client, REST_API, objectMapper);
+                        new PscDiscrepancyFoundListenerImpl(client, REST_API, objectMapper, CORRELATION_ID);
         discrepancy = new PscDiscrepancySurvey();
     }
 

--- a/src/test/java/parser/MailParserTest.java
+++ b/src/test/java/parser/MailParserTest.java
@@ -22,7 +22,7 @@ class MailParserTest {
         byte[] extractedCsvAttachment = mailParser.extractCsvAttachment();
         String extractedCsvAsString = new String(extractedCsvAttachment);
         // Note that an exact match could not be obtained, byte-for-byte,
-        // so the looser contains is used in these tests.
+        // so the looser 'contains' method is used in these tests, rather than equals.
         // The actual decoded bytes seem to start with 0xFF, not a legal UTF-8 character.
         // These are real emails being decoded (albeit anonymised) with real attachments.
         // I can only assume that the start bytes are something weird like magic file bytes.


### PR DESCRIPTION
This will enable CHIPS to correlate its logs with those of the Lambda
(this project). The request ID comes from the AWS
context.getAwsRequestId() in the handler.

Unit tests updated.
No system tests to update.
Sonar checks run (no issues).