### PR TITLE
Reinstate test to see what blows up

### DIFF
--- a/src/test/java/parser/PscDiscrepancySurveyCsvProcessorTest.java
+++ b/src/test/java/parser/PscDiscrepancySurveyCsvProcessorTest.java
@@ -84,6 +84,15 @@ class PscDiscrepancySurveyCsvProcessorTest {
         assertFalse(parser.parseRecords());
     }
 
+    void oneGoodRecordMustParse() throws IOException {
+        byte[] bytes = getFile("src/test/resources/oneGoodRecord.csv");
+        PscDiscrepancySurvey expected = readSurvey("src/test/resources/oneGoodRecord.json");
+        when(listener.created(expected)).thenReturn(true);
+        PscDiscrepancySurveyCsvProcessor parser =
+                        new PscDiscrepancySurveyCsvProcessor(bytes, listener);
+        assertTrue(parser.parseRecords());
+    }
+
     @Test
     void quotedCommasMustNotBlowUpParser() throws IOException {
         byte[] bytes = getFile("src/test/resources/escapedCommas.csv");


### PR DESCRIPTION
The last time that this test was enabled, it blew up in Concourse,
but not locally. Checking it in again to see what happens.