### PR TITLE
Cope with remote content-type change

### DIFF
--- a/src/main/java/handler/Handler.java
+++ b/src/main/java/handler/Handler.java
@@ -88,8 +88,7 @@ public class Handler implements RequestHandler<S3Event, String> {
                         + " is corrupt or missing attachment - moving to rejected folder", me);
                 putFile(s3Bucket, s3Key, REJECTED_FOLDER_PREFIX);
             } catch (IOException e) {
-                LOG.error("The attachment in the email: " + s3Key
-                        + " is not found - moving to the rejected folder");
+                LOG.error("The attachment in the email: {} is not found - moving to the rejected folder", s3Key);
                 putFile(s3Bucket, s3Key, REJECTED_FOLDER_PREFIX);
             }
         }

--- a/src/main/java/handler/PscDiscrepancySurveySender.java
+++ b/src/main/java/handler/PscDiscrepancySurveySender.java
@@ -1,9 +1,11 @@
 package handler;
 
 import java.io.IOException;
+import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.logging.log4j.LogManager;
@@ -45,7 +47,7 @@ public class PscDiscrepancySurveySender implements CsvProcessorListener {
             LOG.info("Callback for discrepancy: {}", sanitisedJson);
             HttpPost httpPost = new HttpPost(postUrl);
             httpPost.setEntity(entity);
-            httpPost.setHeader("Content-type", "text/plain");
+            httpPost.setHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType());
             try (CloseableHttpResponse response = client.execute(httpPost)) {
                 if (response.getStatusLine().getStatusCode() == HttpStatus.SC_ACCEPTED) {
                     LOG.info("Successfully sent JSON");


### PR DESCRIPTION
The CHIPS Rest Interfaces code changed in:
https://github.com/companieshouse/chips-rest-interfaces/commit/ee3fe48f3e72d757196c783c534df078a0062ecc
and it changed the content-type that it expects from this client. This
means that the service is rejecting messages from this Lambda. The fix
is to change what the Lambda sends, to line up with the REST service.

Unit tests cover changes.
Sonar tests pass.
This needs an integration test with CHIPS.