### PR TITLE
Revert "Bump log4j-core from 2.12.1 to 2.13.2"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <aws-lambda-java-events.version>2.2.7</aws-lambda-java-events.version>
         <aws-java-sdk-s3.version>1.11.703</aws-java-sdk-s3.version>
         <aws-lambda-java-log4j2.version>1.1.0</aws-lambda-java-log4j2.version>
-        <log4j-core.version>2.13.2</log4j-core.version>
+        <log4j-core.version>2.12.1</log4j-core.version>
         <log4j-api.version>2.12.1</log4j-api.version>
         <environment-reader-library.version>1.3.6</environment-reader-library.version>
         <json-sanitizer.version>1.2.0</json-sanitizer.version>


### PR DESCRIPTION
Reverts companieshouse/psc-discrepancy-parser#64 due to build failures 