### PR TITLE
Update aws-lambda-java-log4j2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <aws-lambda-java-core.version>1.2.0</aws-lambda-java-core.version>
         <aws-lambda-java-events.version>2.2.7</aws-lambda-java-events.version>
         <aws-java-sdk-s3.version>1.11.703</aws-java-sdk-s3.version>
-        <aws-lambda-java-log4j2.version>1.1.0</aws-lambda-java-log4j2.version>
+        <aws-lambda-java-log4j2.version>1.3.0</aws-lambda-java-log4j2.version>
         <log4j-core.version>2.13.2</log4j-core.version>
         <log4j-api.version>2.13.2</log4j-api.version>
         <environment-reader-library.version>1.3.6</environment-reader-library.version>


### PR DESCRIPTION
See https://aws.amazon.com/security/security-bulletins/AWS-2021-005/

`Customers using the aws-lambda-java-log4j2 (https://repo1.maven.org/maven2/com/amazonaws/aws-lambda-java-log4j2/) library in their functions will need to update to version 1.3.0 and redeploy.`